### PR TITLE
fix doc order error on install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,18 @@ This project uses a number of open source projects:
 	```
 	$ git clone https://github.com/OpenGenus/cosmos-search.git
  	```
-2.  Install local dependencies
 
-       ```
-        pip install -r requirements.txt
-       ```
-3. Go inside main Django app 
+2. Go inside main Django app 
 
 	```
 	$ cd cosmos-search
 	```
+
+3.  Install local dependencies
+
+       ```
+        pip install -r requirements.txt
+       ```
 
 4. Collectstatic files using
 	```


### PR DESCRIPTION
<!-- Thank you for submitting this PR. You are awesome!
-->

**Checklist**

**Which issue does this PR fix?**: 
## fixes: 
In your "Run this search engine locally" section you:
- clone repository
- install requirements
- go to project directory

You need first to go into the project directory and second install requirements with pip


