### PR TITLE
Fix: Broken functionality of calculator

### DIFF
--- a/search/templates/cosmos/calculator.html
+++ b/search/templates/cosmos/calculator.html
@@ -11,10 +11,10 @@
                 <div class="screen">
                     {% if result_val is not None %}
                         <input type="text" value="{{ query }}" name="seq" id="seq" disabled/>
-                        <input type="text" id="resultText" name="txt" value="{{ result_val }}" autocomplete="off" onfocus="focusOn(this.value)"/>
+                        <input type="text" id="resultText" name="txt" value="{{ result_val }}" onclick="textD(this.value)" autocomplete="off" onfocus="focusOn(this.value)"/>
                     {% else %}
                         <input type="text" value="" name="seq" id="seq" disabled/>
-                        <input type="text" id="resultText" name="txt" value="0" autocomplete="off" onfocus="focusOn(this.value)"/>
+                        <input type="text" id="resultText" name="txt" value="0" onclick="textD(this.value)" autocomplete="off" onfocus="focusOn(this.value)"/>
                     {% endif %}
                     <input type="submit" hidden>
                 </div>
@@ -66,31 +66,26 @@
 <script>
     $(document).ready(function() {
       window.onload = function () {
-        $("#resultText").focus()
-        frm.got_result = true
+        $("#resultText").focus();
+
       }
     });
 
     function focusOn(x) {
-      var temp_value = x
-      frm.txt.value = ""
-      frm.txt.value = temp_value
+      var temp_value = x;
+      frm.txt.value = "";
+      frm.txt.value = temp_value;
     }
 
     function displ(x, end) {
-      if (frm.got_result) {
-        if (frm.seq.value != "") {
-          frm.seq.value += " = " + frm.txt.value
-        }
-        else {
-          frm.seq.value = frm.txt.value
-        }
-        frm.txt.value = "0"
-        frm.got_result = false
-      }
 
       if (frm.txt.value == "0" && x != ".") {
-        frm.txt.value = ""
+        frm.txt.value = "";
+      }
+
+      if (frm.txt.value == "Error"){
+          frm.txt.value = "";
+          frm.seq.value = "";
       }
 
       if (end === "(") {
@@ -103,12 +98,19 @@
 
     function cleartext(x) {
       if (frm.got_result) {
-        displ("")
+        displ("");
       }
-      frm.txt.value = ""
+      frm.txt.value = "";
     }
 
     function equals(x) {
       $("#cl").submit()
+    }
+
+    function textD(x) {
+        if(x == "Error"){
+            frm.txt.value = "";
+            frm.seq.value = "";
+        }
     }
 </script>

--- a/search/templates/cosmos/calculator.html
+++ b/search/templates/cosmos/calculator.html
@@ -97,9 +97,6 @@
     }
 
     function cleartext(x) {
-      if (frm.got_result) {
-        displ("");
-      }
       frm.txt.value = "";
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR. You are awesome!
-->
**Checklist**
- [X] My branch is up-to-date with the upstream `develop` branch.
- [ ] I have added necessary documentation (if appropriate).

**Which issue does this PR fix?**: 
fixes: #

<!-- Brief description of what this PR does.
Add issue number here. If you do not solve the issue entirely, please change the message e.g. "First steps for issues #IssueNumber" -->

**Why do we need this PR?**:
This PR modify some functionality in the calculator

- In case of `Error,` if a user clicks either any button or in the `input box` then whole text(`result` and `expression`) would be replaced with the value entered by the user.

- The user can use the calculated result in further calculations.
  
If relevant, please include a screenshot.

![screenshot from 2018-04-02 16-16-10](https://user-images.githubusercontent.com/25522394/38194189-a7c4568e-3693-11e8-8111-acdec5d85e2f.png)