### PR TITLE
click default remove

### DIFF
--- a/search/templates/cosmos/header.html
+++ b/search/templates/cosmos/header.html
@@ -82,7 +82,7 @@
             <div class="col-8 nopadding border">
                 <form class="form-inline justify-content-center" id="formq" action="{% url 'query' %}" method="GET">
                     <div class="input-group stylish-input-group">
-                        <input class="form-control text-center" id="search" type="search" size="128" placeholder="{{ algo_name }}" value="{{ algo_name }}" aria-label="Search" name="q">
+                        <input class="form-control text-center" id="search" type="search" size="128" placeholder="{{ algo_name }}" value="{{ algo_name }}" aria-label="Search" name="q" onfocus= "document.getElementById('search').value=''">
                         <span class="input-group-addon">
                         <button type="submit" style="outline: none;">
                             <i class="fa fa-search"></i>


### PR DESCRIPTION
**Checklist**

- [x] My branch is up-to-date with the upstream `develop` branch.
- [ ] I have added necessary documentation (if appropriate).

**Which issue does this PR fix?**: 
fixes: #
*Currently the search bar has a default tag in it when we open cosmos search. 
*We need to click on X to remove them. 
*Now just clicking on search bar will remove the default tag.

**Why do we need this PR?**:
I think that it is more intuitive if the default tag is removed when we click the search bar instead of clicking on the X. 

If there is any work still left to do, please add it here.

**TODOs (if any)**:
*Should I remove the X button?

